### PR TITLE
Fix warnings for swift name and add mul op stubs

### DIFF
--- a/Sources/simdFilament/SIMDMatrix.swift
+++ b/Sources/simdFilament/SIMDMatrix.swift
@@ -21,11 +21,15 @@ public extension SIMDMatrix {
         return true
     }
 
-    init(_ columns: [SIMD4<Float>]) {
+    init <U> (_ columns: [SIMD4 <U>]) {
         preconditionFailure()
     }
 
-    init(rows: [SIMD4<Float>]) {
+    init <U> (_ scalar: U) {
+        preconditionFailure()
+    }
+
+    init <U> (rows: [SIMD4 <U>]) {
         preconditionFailure()
     }
 

--- a/Sources/simdFilament/SIMDMatrix.swift
+++ b/Sources/simdFilament/SIMDMatrix.swift
@@ -38,3 +38,10 @@ public extension SIMDMatrix {
         set { self[column][row] = newValue }
     }
 }
+
+extension simd_float4x4 {
+    public static func * (lhs: simd_float4x4,
+                          rhs: simd_float4x4) -> simd_float4x4 {
+        preconditionFailure()
+    }
+}

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -22,6 +22,13 @@ extension simd_quatd: Equatable {
     }
 }
 
+extension simd_quatd {
+    public static func * (lhs: simd_quatd,
+                          rhs: simd_quatd) -> simd_quatd {
+        preconditionFailure()
+    }
+}
+
 public extension simd_quatf {
     init(angle: Float,
          axis: simd_float3) {
@@ -39,6 +46,13 @@ public extension simd_quatf {
 extension simd_quatf: Equatable {
     public static func == (lhs: simd_quatf,
                            rhs: simd_quatf) -> Bool {
+        preconditionFailure()
+    }
+}
+
+extension simd_quatf {
+    public static func * (lhs: simd_quatf,
+                          rhs: simd_quatf) -> simd_quatf {
         preconditionFailure()
     }
 }

--- a/Sources/simdFilamentC/include/simd/matrix_casts.h
+++ b/Sources/simdFilamentC/include/simd/matrix_casts.h
@@ -4,7 +4,7 @@
 #include "simd/vector_casts.h"
 
 #define DEFINE_CAST(from, to, to_column_type, num_columns, swift_args) \
-    __attribute__((swift_name("simd_" #to ".init(_:)"))) \
+    SWIFT_NAME("simd_" #to ".init(_:)") \
     simd_ ## to SIMD_OVERLOADABLE \
     simd_make_ ## to (simd_ ## from v) { \
         simd_ ## to out; \

--- a/Sources/simdFilamentC/include/simd/matrix_constructors.h
+++ b/Sources/simdFilamentC/include/simd/matrix_constructors.h
@@ -3,7 +3,7 @@
 #include "simd/types.h"
 
 #define CONSTRUCT_2_COLUMNS(type, column_type) \
-    __attribute__((swift_name("simd_" #type ".init(_:_:)"))) \
+    SWIFT_NAME("simd_" #type ".init(_:_:)") \
     simd_ ## type SIMD_OVERLOADABLE \
     simd_make_ ## type(simd_ ## column_type col0, \
                        simd_ ## column_type col1) \
@@ -13,7 +13,7 @@
     } \
 
 #define CONSTRUCT_3_COLUMNS(type, column_type) \
-    __attribute__((swift_name("simd_" #type ".init(_:_:_:)"))) \
+    SWIFT_NAME("simd_" #type ".init(_:_:_:)") \
     simd_ ## type SIMD_OVERLOADABLE \
     simd_make_ ## type(simd_ ## column_type col0, \
                        simd_ ## column_type col1, \
@@ -24,7 +24,7 @@
     } \
 
 #define CONSTRUCT_4_COLUMNS(type, column_type) \
-    __attribute__((swift_name("simd_" #type ".init(_:_:_:_:)"))) \
+    SWIFT_NAME("simd_" #type ".init(_:_:_:_:)") \
     simd_ ## type SIMD_OVERLOADABLE \
     simd_make_ ## type(simd_ ## column_type col0, \
                        simd_ ## column_type col1, \

--- a/Sources/simdFilamentC/include/simd/matrix_math.h
+++ b/Sources/simdFilamentC/include/simd/matrix_math.h
@@ -5,7 +5,7 @@
 #include "simd/vector_geometry.h"
 
 #define MAT_UNARY_OPS(base_type, rows, cols) \
-    __attribute__((swift_name("getter:simd_" #base_type #cols "x" #rows ".transpose(self:)"))) \
+    SWIFT_NAME("getter:simd_" #base_type #cols "x" #rows ".transpose(self:)") \
     simd_ ## base_type ## rows ## x ## cols SIMD_OVERLOADABLE \
     simd_transpose(simd_ ## base_type ## cols ## x ## rows m) \
     { \
@@ -145,27 +145,27 @@ extern "C"
     MAT_PRODS_ALL_DIMS(float)
     MAT_PRODS_ALL_DIMS(double)
 
-    __attribute__((swift_name("getter:simd_float2x2.inverse(self:)")))
+    SWIFT_NAME("getter:simd_float2x2.inverse(self:)")
     simd_float2x2 SIMD_OVERLOADABLE_NOINLINE
     simd_inverse(simd_float2x2 m);
 
-    __attribute__((swift_name("getter:simd_float3x3.inverse(self:)")))
+    SWIFT_NAME("getter:simd_float3x3.inverse(self:)")
     simd_float3x3 SIMD_OVERLOADABLE_NOINLINE
     simd_inverse(simd_float3x3 m);
 
-    __attribute__((swift_name("getter:simd_float4x4.inverse(self:)")))
+    SWIFT_NAME("getter:simd_float4x4.inverse(self:)")
     simd_float4x4 SIMD_OVERLOADABLE_NOINLINE
     simd_inverse(simd_float4x4 m);
 
-    __attribute__((swift_name("getter:simd_double2x2.inverse(self:)")))
+    SWIFT_NAME("getter:simd_double2x2.inverse(self:)")
     simd_double2x2 SIMD_OVERLOADABLE_NOINLINE
     simd_inverse(simd_double2x2 m);
 
-    __attribute__((swift_name("getter:simd_double3x3.inverse(self:)")))
+    SWIFT_NAME("getter:simd_double3x3.inverse(self:)")
     simd_double3x3 SIMD_OVERLOADABLE_NOINLINE
     simd_inverse(simd_double3x3 m);
 
-    __attribute__((swift_name("getter:simd_double4x4.inverse(self:)")))
+    SWIFT_NAME("getter:simd_double4x4.inverse(self:)")
     simd_double4x4 SIMD_OVERLOADABLE_NOINLINE
     simd_inverse(simd_double4x4 m);
 

--- a/Sources/simdFilamentC/include/simd/types.h
+++ b/Sources/simdFilamentC/include/simd/types.h
@@ -4,6 +4,12 @@
 #define SIMD_OVERLOADABLE static inline SIMD_ATTRIBUTES __attribute__((overloadable))
 #define SIMD_OVERLOADABLE_NOINLINE SIMD_ATTRIBUTES __attribute__((overloadable))
 
+#if __has_attribute(swift_name)
+#define SWIFT_NAME(name) __attribute__((swift_name(name)))
+#else
+#define SWIFT_NAME(name)
+#endif
+
 #ifdef __cplusplus
 #define simd_bool bool
 #else


### PR DESCRIPTION
Two patches:
1. Add stubs for * operator for simd_float4x4, simd_quatd and simd_quatf.
2. Add a helper for swift_name attribute usage to avoid generating warnings when it is not available.
3. Use generics for scalar constructors to avoid having to redundantly create them.