### PR TITLE
Add make float3 variant and fast length impl

### DIFF
--- a/Sources/simdFilament/SIMDMatrix.swift
+++ b/Sources/simdFilament/SIMDMatrix.swift
@@ -43,6 +43,27 @@ public extension SIMDMatrix {
     }
 }
 
+extension simd_double3x3 {
+    public static func * (lhs: simd_double3x3,
+                          rhs: simd_double3x3) -> simd_double3x3 {
+        preconditionFailure()
+    }
+}
+
+extension simd_float3x3 {
+    public static func * (lhs: simd_float3x3,
+                          rhs: simd_float4x3) -> simd_float4x3 {
+        preconditionFailure()
+    }
+}
+
+extension simd_float4x3 {
+    public static func * (lhs: simd_float4x3,
+                          rhs: simd_float4x4) -> simd_float4x3 {
+        preconditionFailure()
+    }
+}
+
 extension simd_float4x4 {
     public static func * (lhs: simd_float4x4,
                           rhs: simd_float4x4) -> simd_float4x4 {

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -63,4 +63,14 @@ extension simd_quatf {
                           rhs: simd_quatf) -> simd_quatf {
         preconditionFailure()
     }
+
+    public static func / (lhs: simd_quatf,
+                          rhs: simd_quatf) -> simd_quatf {
+        preconditionFailure()
+    }
+
+    public static func / (lhs: simd_quatf,
+                          rhs: Float) -> simd_quatf {
+        preconditionFailure()
+    }
 }

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -74,3 +74,7 @@ extension simd_quatf {
         preconditionFailure()
     }
 }
+
+public func simd_angle(_ q: simd_quatf) -> Float {
+    preconditionFailure()
+}

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -30,6 +30,14 @@ extension simd_quatd {
 }
 
 public extension simd_quatf {
+    init(_ rotationMatrix: simd_float3x3) {
+        preconditionFailure()
+    }
+
+    init(_ rotationMatrix: simd_float4x4) {
+        preconditionFailure()
+    }
+
     init(angle: Float,
          axis: simd_float3) {
         preconditionFailure()

--- a/Sources/simdFilamentC/include/simd/vector_constructors.h
+++ b/Sources/simdFilamentC/include/simd/vector_constructors.h
@@ -93,6 +93,12 @@ extern "C"
         return simd_make_float3(x, yz[0], yz[1]);
     }
 
+    simd_float3 SIMD_OVERLOADABLE
+    simd_make_float3(simd_float4 xyzw)
+    {
+        return xyzw.xyz;
+    }
+
     simd_float4 SIMD_OVERLOADABLE
     simd_make_float4(simd_float2 xy)
     {

--- a/Sources/simdFilamentC/include/simd/vector_geometry.h
+++ b/Sources/simdFilamentC/include/simd/vector_geometry.h
@@ -65,6 +65,9 @@ extern "C"
     ALL_UNARY_REDUCE_OPS(simd_length_squared, float, simd_dot(_x, _x))
     ALL_UNARY_REDUCE_OPS(simd_length_squared, double, simd_dot(_x, _x))
 
+    ALL_UNARY_REDUCE_OPS(simd_fast_length, float, sqrtf(simd_length_squared(_x)))
+    ALL_UNARY_REDUCE_OPS(simd_fast_length, double, sqrt(simd_length_squared(_x)))
+
     ALL_UNARY_REDUCE_OPS(simd_length, float, sqrtf(simd_length_squared(_x)))
     ALL_UNARY_REDUCE_OPS(simd_length, double, sqrt(simd_length_squared(_x)))
 


### PR DESCRIPTION
Two patches:
1. Add simd_make_float3 for float4 -> float3 conversion.
2. Add simd_fast_length based on simd_length.
3. Add multiplication helpers for double3x3, float3x3 and float4x4.
4. Add rotationMatrix constructor variants for simd_quatf.
5. Add division helpers for simd_quatf.
6. Add angle computation stub for simd_quatf.