### PR TITLE
Add stubs for common matrix and quat operations

### DIFF
--- a/Sources/simdFilament/SIMDMatrix.swift
+++ b/Sources/simdFilament/SIMDMatrix.swift
@@ -50,7 +50,29 @@ extension simd_double3x3 {
     }
 }
 
+extension simd_double4x4 {
+    public static func * (lhs: simd_double4x4,
+                          rhs: simd_double4x4) -> simd_double4x4 {
+        preconditionFailure()
+    }
+}
+
 extension simd_float3x3 {
+    public static func * (lhs: simd_float3x3,
+                          rhs: simd_float3) -> simd_float3 {
+        preconditionFailure()
+    }
+
+    public static func * (lhs: simd_float3,
+                          rhs: simd_float3x3) -> simd_float3 {
+        preconditionFailure()
+    }
+
+    public static func * (lhs: simd_float3x3,
+                          rhs: simd_float3x3) -> simd_float3x3 {
+        preconditionFailure()
+    }
+
     public static func * (lhs: simd_float3x3,
                           rhs: simd_float4x3) -> simd_float4x3 {
         preconditionFailure()
@@ -65,6 +87,16 @@ extension simd_float4x3 {
 }
 
 extension simd_float4x4 {
+    public static func * (lhs: simd_float4x4,
+                          rhs: simd_float4) -> simd_float4 {
+        preconditionFailure()
+    }
+
+    public static func * (lhs: simd_float4,
+                          rhs: simd_float4x4) -> simd_float4 {
+        preconditionFailure()
+    }
+
     public static func * (lhs: simd_float4x4,
                           rhs: simd_float4x4) -> simd_float4x4 {
         preconditionFailure()

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -43,10 +43,20 @@ public extension simd_quatf {
         preconditionFailure()
     }
 
+    init(from: SIMD3 <Float>,
+         to: SIMD3 <Float>) {
+        preconditionFailure()
+    }
+
     init(ix: Float,
          iy: Float,
          iz: Float,
          r: Float) {
+        preconditionFailure()
+    }
+
+    init(real: Float,
+         imag: SIMD3 <Float>) {
         preconditionFailure()
     }
 }

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -107,6 +107,26 @@ extension simd_quatf {
     }
 }
 
+extension simd_quatf: RangeReplaceableCollection {
+    public typealias Element = Float
+    public typealias Index = Int
+
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { 4 }
+
+    public subscript(bounds: Self.Index) -> Self.Element {
+        preconditionFailure()
+    }
+
+    public func append <S: Sequence> (contentsOf newElements: S) where Element == S.Element {
+        preconditionFailure()
+    }
+
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+}
+
 public func simd_angle(_ q: simd_quatf) -> Float {
     preconditionFailure()
 }

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -85,6 +85,28 @@ extension simd_quatf {
     }
 }
 
+extension simd_quatf {
+    public var angle: Float {
+        return simd_angle(self)
+    }
+
+    public var axis: SIMD3 <Float> {
+        preconditionFailure()
+    }
+
+    public var inverse: simd_quatf {
+        preconditionFailure()
+    }
+
+    public var normalized: simd_quatf {
+        preconditionFailure()
+    }
+
+    public func act(_ vector: SIMD3 <Float>) -> SIMD3 <Float> {
+        preconditionFailure()
+    }
+}
+
 public func simd_angle(_ q: simd_quatf) -> Float {
     preconditionFailure()
 }

--- a/Sources/simdFilamentC/include/simd/vector_constructors.h
+++ b/Sources/simdFilamentC/include/simd/vector_constructors.h
@@ -75,6 +75,18 @@ extern "C"
 
 #pragma mark Composite Constructors
 
+    simd_float2 SIMD_OVERLOADABLE
+    simd_make_float2(simd_float3 xyz)
+    {
+        return simd_make_float2(xyz[0], xyz[1]);
+    }
+
+    simd_float2 SIMD_OVERLOADABLE
+    simd_make_float2(simd_float4 xyzw)
+    {
+        return simd_make_float2(xyzw[0], xyzw[1]);
+    }
+
     simd_float3 SIMD_OVERLOADABLE
     simd_make_float3(simd_float2 xy)
     {
@@ -145,6 +157,12 @@ extern "C"
     simd_make_float4(simd_float3 xyz, float w)
     {
         return simd_make_float4(xyz[0], xyz[1], xyz[2], w);
+    }
+
+    simd_float4 SIMD_OVERLOADABLE
+    simd_make_float4(simd_float3 xyz)
+    {
+        return simd_make_float4(xyz, 0);
     }
 
     simd_float4 SIMD_OVERLOADABLE

--- a/Sources/simdFilamentC/include/simd/vector_math.h
+++ b/Sources/simdFilamentC/include/simd/vector_math.h
@@ -167,6 +167,12 @@ extern "C"
         return a + t * (b - a);
     }
 
+    float SIMD_OVERLOADABLE
+    simd_mix(float a, float b, float t)
+    {
+        return mix(a, b, t);
+    }
+
     simd_float2 SIMD_OVERLOADABLE
     simd_mix(simd_float2 a, simd_float2 b, simd_float2 t)
     {


### PR DESCRIPTION
Jim, here are a set of 6 patches that enable more useful simd functions.

1. Add RangeReplaceableCollection conformance to allow simd_quatf.map convenience accessors.
2. Add stubs for simd_quatf act, angle, axis inverse and normalized.
3. simd_quatf constructors for from:to: and real:imag:.
4. Add multiplication helpers for double4x4 and float3x3 and 4x4.
5. Add downcasting variants of simd_float3/4 and upcasting variant of simd_float3.
6. Add simd_mix named equivalent for mix.