### PR TITLE
Add scale and slerp stub ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 /.build
+/.swiftpm
 /Packages
 /*.xcodeproj
 tags
 xcuserdata/
+DerivedData/

--- a/Sources/simdFilament/SIMDMatrix.swift
+++ b/Sources/simdFilament/SIMDMatrix.swift
@@ -88,6 +88,16 @@ extension simd_float4x3 {
 
 extension simd_float4x4 {
     public static func * (lhs: simd_float4x4,
+                          rhs: Float) -> simd_float4x4 {
+        preconditionFailure()
+    }
+
+    public static func * (lhs: Float,
+                          rhs: simd_float4x4) -> simd_float4x4 {
+        preconditionFailure()
+    }
+
+    public static func * (lhs: simd_float4x4,
                           rhs: simd_float4) -> simd_float4 {
         preconditionFailure()
     }

--- a/Sources/simdFilament/SIMDQuat.swift
+++ b/Sources/simdFilament/SIMDQuat.swift
@@ -135,3 +135,9 @@ public func simd_quaternion(_ from: simd_float3,
                             _ to: simd_float3) -> simd_quatf {
     preconditionFailure()
 }
+
+public func simd_slerp(_ q0: simd_quatf,
+                       _ q1: simd_quatf,
+                       _ t: Float) -> simd_quatf {
+    preconditionFailure()
+}


### PR DESCRIPTION
3 patches:
1. Add matrix scaling for float4x4 stub.
2. Add slerp for quat interpolation stub.
3. Update gitignore to avoid picking up swiftpm or DerivedData dirs.